### PR TITLE
fix: deliver reminders to the whole class, not just course staff

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node src/server.js",
-    "test-server": "node src/server.js"
+    "test-server": "node src/server.js",
+    "test": "node --test \"src/**/*.test.js\""
   },
   "dependencies": {
     "dotenv": "^16.0.0",

--- a/services/gradesync_input/backfill_course_code.py
+++ b/services/gradesync_input/backfill_course_code.py
@@ -1,0 +1,99 @@
+"""Backfill `course_code` on student docs that predate registration setting it.
+
+The daily pipeline routes each student to an assignment catalog by `course_code`.
+Student docs created before registration wrote that field match no catalog, so those
+students silently receive nothing. This fills the field from the class roster, and
+falls back to the deployment's course for students who registered but are not on the
+roster (staff, late adds).
+
+Dry run by default — prints the planned writes and changes nothing. Pass --apply to
+commit them.
+
+    python3 services/gradesync_input/backfill_course_code.py
+    python3 services/gradesync_input/backfill_course_code.py --apply
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+DEFAULT_COURSE_CODE = "CS61A"
+STUDENTS_COLLECTION = "students"
+ROSTER_COLLECTION = "class_roster"
+
+
+def decide_course_code(
+    student: Dict[str, Any],
+    roster: Dict[str, Dict[str, Any]],
+    default_course_code: str,
+) -> Optional[str]:
+    """Return the course_code to write, or None to leave the doc untouched."""
+    if str(student.get("course_code") or "").strip():
+        return None
+    email = str(student.get("email") or "").strip().lower()
+    entry = roster.get(email) or {}
+    return str(entry.get("course_code") or "").strip() or default_course_code
+
+
+def _load(db):
+    roster = {
+        str((d.to_dict() or {}).get("email") or d.id).strip().lower(): (d.to_dict() or {})
+        for d in db.collection(ROSTER_COLLECTION).stream()
+    }
+    students = [(d.id, d.to_dict() or {}) for d in db.collection(STUDENTS_COLLECTION).stream()]
+    return roster, students
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Commit the writes (default: dry run)")
+    parser.add_argument("--course-code", default=DEFAULT_COURSE_CODE, help="Fallback course for students not on the roster")
+    args = parser.parse_args()
+
+    import firebase_admin
+    from firebase_admin import credentials, firestore
+    from shared import settings
+
+    if not firebase_admin._apps:
+        firebase_admin.initialize_app(
+            credentials.Certificate(str(settings.FIREBASE_SERVICE_ACCOUNT_PATH)),
+            {"projectId": settings.FIREBASE_PROJECT_ID},
+        )
+    db = firestore.client()
+
+    roster, students = _load(db)
+    print(f"Loaded {len(students)} students and {len(roster)} roster entries.\n")
+
+    planned = []
+    for doc_id, student in students:
+        course_code = decide_course_code(student, roster, args.course_code)
+        if course_code:
+            email = str(student.get("email") or doc_id).strip().lower()
+            planned.append((doc_id, email, course_code, email in roster))
+
+    if not planned:
+        print("Nothing to backfill — every student already has a course_code.")
+        return
+
+    for _, email, course_code, on_roster in sorted(planned, key=lambda p: p[1]):
+        source = "roster" if on_roster else "default"
+        print(f"  {email:42} -> course_code={course_code}  ({source})")
+
+    print(f"\n{len(planned)} student(s) would be updated.")
+
+    if not args.apply:
+        print("\nDRY RUN — nothing written. Re-run with --apply to commit.")
+        return
+
+    batch = db.batch()
+    for doc_id, _, course_code, _ in planned:
+        batch.update(db.collection(STUDENTS_COLLECTION).document(doc_id), {"course_code": course_code})
+    batch.commit()
+    print(f"\n✅ Updated {len(planned)} student doc(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/gradesync_input/db_fetch.py
+++ b/services/gradesync_input/db_fetch.py
@@ -563,6 +563,23 @@ def format_due_datetime(dt_value: datetime) -> str:
     return dt_value.strftime("%Y-%m-%d %H:%M")
 
 
+_UNROUTABLE_STUDENTS_WARNED: set = set()
+
+
+def _warn_unroutable_student(student_email: Any, course_code: str) -> None:
+    """Surface students whose course_code matches no catalog, once each per run.
+
+    These students silently receive nothing, so a run that drops people must say so
+    rather than reporting a clean summary.
+    """
+    key = str(student_email)
+    if key in _UNROUTABLE_STUDENTS_WARNED:
+        return
+    _UNROUTABLE_STUDENTS_WARNED.add(key)
+    reason = f"course_code={course_code!r}" if course_code else "course_code is unset"
+    print(f"⚠️  No assignment catalog for {student_email} ({reason}) — cannot notify.")
+
+
 def build_assignment_payload(
     student: Dict[str, Any],
     code: str,
@@ -586,13 +603,14 @@ def build_assignment_payload(
         print(f"{'='*80}")
     
     course_code = (student.get("course_code") or "").strip()
-    # course_lookup = lookup.get(course_code)
-    # if course_lookup is None and course_code:
-    #     course_lookup = lookup.get("")
-    # This forces the script to look into the CS10 assignments folder
-    course_lookup = lookup.get(course_code) or lookup.get("CS10")
+    # No cross-course fallback: a student whose course_code is unset or unknown must
+    # match nothing rather than silently inherit another course's catalog. The old
+    # fallback pointed at CS10 and quietly evaluated every CS61A student against five
+    # long-expired CS10 projects, so they never matched anything.
+    course_lookup = lookup.get(course_code) if course_code else None
+    if course_lookup is None:
+        _warn_unroutable_student(student_email, course_code)
 
-    
     if is_target_student or debug:
         print(f"   Course code: '{course_code}' (empty='{not course_code}')")
         print(f"   Course lookup found: {course_lookup is not None}")
@@ -1018,9 +1036,12 @@ def is_missing_submission(
     """Return True if the student has not submitted the assignment."""
     key = (student_email.strip().lower(), assignment_name.strip())
     status = submission_lookup.get(key)
-    # Not in spreadsheet at all — not a student in the class, don't notify
+    # No row yet — the assignment is newer than the latest GradeSync sync, which is
+    # exactly the case on release day. Absence of a row is not evidence of a
+    # submission, so treat it as not submitted and let the reminder through.
+    # Enrollment is already enforced upstream by the students collection.
     if status is None:
-        return False
+        return True
     # A timestamp means submitted; "missing" means not submitted
     return status.strip().lower() == "missing"
 

--- a/services/gradesync_input/test_backfill_course_code.py
+++ b/services/gradesync_input/test_backfill_course_code.py
@@ -1,0 +1,45 @@
+"""Tests for the course_code backfill decision logic.
+
+Existing student docs predate registration writing course_code, so they route to no
+catalog and receive nothing. The backfill fills the field from the class roster,
+falling back to the deployment's course for students who registered but are not on
+the roster. Students that already have a course_code are left alone.
+"""
+
+import backfill_course_code as backfill
+
+
+ROSTER = {
+    "onroster@berkeley.edu": {"course_code": "CS61A"},
+    "othercourse@berkeley.edu": {"course_code": "CS10"},
+}
+
+
+def test_fills_from_roster():
+    student = {"email": "onroster@berkeley.edu"}
+    assert backfill.decide_course_code(student, ROSTER, "CS61A") == "CS61A"
+
+
+def test_uses_roster_course_even_when_it_differs_from_the_default():
+    student = {"email": "othercourse@berkeley.edu"}
+    assert backfill.decide_course_code(student, ROSTER, "CS61A") == "CS10"
+
+
+def test_falls_back_to_default_when_not_on_roster():
+    student = {"email": "staff@berkeley.edu"}
+    assert backfill.decide_course_code(student, ROSTER, "CS61A") == "CS61A"
+
+
+def test_leaves_existing_course_code_alone():
+    student = {"email": "onroster@berkeley.edu", "course_code": "CS10"}
+    assert backfill.decide_course_code(student, ROSTER, "CS61A") is None
+
+
+def test_treats_blank_course_code_as_missing():
+    student = {"email": "onroster@berkeley.edu", "course_code": "   "}
+    assert backfill.decide_course_code(student, ROSTER, "CS61A") == "CS61A"
+
+
+def test_matches_roster_case_insensitively():
+    student = {"email": "OnRoster@Berkeley.EDU"}
+    assert backfill.decide_course_code(student, ROSTER, "CS61A") == "CS61A"

--- a/services/gradesync_input/test_reminder_delivery_gaps.py
+++ b/services/gradesync_input/test_reminder_delivery_gaps.py
@@ -1,0 +1,110 @@
+"""Tests for the two gaps that silenced reminders for everyone but course staff.
+
+Gap 1 — course routing: a student whose `course_code` is unset must not be
+silently evaluated against a different course's catalog. Registration did not
+write the field, so every self-registered student fell through to a hardcoded
+CS10 fallback holding stale assignments and matched nothing, every day.
+
+Gap 2 — the submission gate: `is_missing_submission` treated "no submission row"
+as "already handled", so the caller skipped the student. On the day an assignment
+is released nobody has a row yet, which silenced release-day reminders for the
+whole class. Absence of a row means not submitted, so the student is notified;
+only a recorded submission suppresses the reminder.
+"""
+
+from datetime import datetime
+
+import db_fetch
+
+
+TODAY = datetime(2026, 7, 20, 9, 0, 0)
+RELEASED_TODAY = datetime(2026, 7, 20, 0, 0, 0)
+DUE_TOMORROW = datetime(2026, 7, 21, 23, 59, 59)
+
+
+class Args:
+    """Stand-in for the argparse namespace `_build_reminder_for_student` reads."""
+
+    debug = False
+
+
+def make_student(**overrides):
+    student = {
+        "email": "student@berkeley.edu",
+        "id": "stu1",
+        "course_code": "CS61A",
+        "days_before_deadline": 1,
+        "email_pref": True,
+    }
+    student.update(overrides)
+    return student
+
+
+def make_lookup(assignment_name="Lab 7", course="CS61A", release=RELEASED_TODAY, due=DUE_TOMORROW):
+    return {
+        course: {
+            assignment_name: {
+                "assignment_name": assignment_name,
+                "deadline": due,
+                "release": release,
+                "resources": [],
+            }
+        }
+    }
+
+
+def build(student, lookup, submissions):
+    return db_fetch._build_reminder_for_student(
+        student, lookup, submissions, TODAY, "___no_target___", Args
+    )
+
+
+# ── Gap 2: the submission gate ────────────────────────────────────────────────
+
+def test_notifies_when_no_submission_row_exists():
+    """The release-day case: the assignment just came out, so no rows exist yet."""
+    reminder = build(make_student(), make_lookup(), submissions={})
+    assert reminder is not None
+    assert [a["assignment_name"] for a in reminder["assignments"]] == ["Lab 7"]
+
+
+def test_notifies_when_status_is_missing():
+    """Existing behavior: an explicit 'missing' status still notifies."""
+    submissions = {("student@berkeley.edu", "Lab 7"): "missing"}
+    reminder = build(make_student(), make_lookup(), submissions)
+    assert reminder is not None
+
+
+def test_skips_when_submission_is_recorded():
+    """Existing behavior must survive: a recorded submission suppresses the reminder."""
+    submissions = {("student@berkeley.edu", "Lab 7"): "2026-07-20 18:18:11 -0700"}
+    assert build(make_student(), make_lookup(), submissions) is None
+
+
+def test_is_missing_submission_treats_absent_row_as_not_submitted():
+    assert db_fetch.is_missing_submission("student@berkeley.edu", "Lab 7", {}) is True
+
+
+def test_is_missing_submission_still_false_for_recorded_submission():
+    submissions = {("student@berkeley.edu", "Lab 7"): "2026-07-20 18:18:11 -0700"}
+    assert db_fetch.is_missing_submission("student@berkeley.edu", "Lab 7", submissions) is False
+
+
+# ── Gap 1: course routing ─────────────────────────────────────────────────────
+
+def test_unset_course_code_does_not_borrow_another_courses_catalog():
+    """An unset course_code must match nothing rather than silently reading CS10."""
+    lookup = make_lookup(assignment_name="Project 1", course="CS10")
+    assert db_fetch.build_assignment_payload(make_student(course_code=None), "Project 1", lookup, TODAY) is None
+
+
+def test_unknown_course_code_does_not_borrow_another_courses_catalog():
+    lookup = make_lookup(assignment_name="Project 1", course="CS10")
+    assert db_fetch.build_assignment_payload(make_student(course_code="CS61A"), "Project 1", lookup, TODAY) is None
+
+
+def test_matching_course_code_still_resolves():
+    """The fix must not break the students whose course_code is set correctly."""
+    payload = db_fetch.build_assignment_payload(make_student(course_code="CS61A"), "Lab 7", make_lookup(), TODAY)
+    assert payload is not None
+    assert payload["assignment_name"] == "Lab 7"

--- a/src/api/reminders/register.js
+++ b/src/api/reminders/register.js
@@ -3,6 +3,35 @@ import { verifyUserAuth } from '../auth/verifyUser.js';
 import { getStudyStatus } from '../study/studyStatus.js';
 import { LOCKOUT_MESSAGE } from '../study/messages.js';
 
+// The daily pipeline routes each student to an assignment catalog by course_code.
+// A student doc without it matches no catalog and silently receives nothing, so
+// registration must always set one.
+export const DEFAULT_COURSE_CODE = process.env.COURSE_CODE || 'CS61A';
+
+// The class roster is authoritative; students who registered but are not on it
+// (staff, late adds) still need a course to be reachable.
+export function resolveCourseCode(rosterEntry) {
+  return rosterEntry?.course_code || DEFAULT_COURSE_CODE;
+}
+
+export function buildNewStudent({ email, displayName, courseCode }) {
+  const now = new Date().toISOString();
+  return {
+    email,
+    preferred_first_name: displayName ? displayName.split(' ')[0] : null,
+    course_code: courseCode,
+    phone_number: null,
+    discord_id: null,
+    days_before_deadline: 1,
+    release_reminder: true,
+    email_pref: false,
+    phone_pref: false,
+    discord_pref: false,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
 // Creates a minimal student document on first login (idempotent — no-op if already exists).
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
@@ -38,19 +67,12 @@ export default async function handler(req, res) {
       return res.status(200).json({ success: true, created: false, data: existing.data() });
     }
 
-    const newStudent = {
+    const rosterSnap = await db.collection('class_roster').doc(loginEmail).get();
+    const newStudent = buildNewStudent({
       email: loginEmail,
-      preferred_first_name: display_name ? display_name.split(' ')[0] : null,
-      phone_number: null,
-      discord_id: null,
-      days_before_deadline: 1,
-      release_reminder: true,
-      email_pref: false,
-      phone_pref: false,
-      discord_pref: false,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    };
+      displayName: display_name,
+      courseCode: resolveCourseCode(rosterSnap.exists ? rosterSnap.data() : null),
+    });
 
     await docRef.set(newStudent);
     return res.status(201).json({ success: true, created: true, data: newStudent });

--- a/src/api/reminders/register.test.js
+++ b/src/api/reminders/register.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DEFAULT_COURSE_CODE, resolveCourseCode, buildNewStudent } from './register.js';
+
+// Registration used to create student docs with no course_code at all. The daily
+// pipeline routes each student to an assignment catalog by that field, so every
+// self-registered student matched nothing and silently received no reminders.
+
+test('resolveCourseCode prefers the roster entry', () => {
+  assert.equal(resolveCourseCode({ course_code: 'CS61A' }), 'CS61A');
+});
+
+test('resolveCourseCode falls back to the default when the student is not on the roster', () => {
+  assert.equal(resolveCourseCode(null), DEFAULT_COURSE_CODE);
+});
+
+test('resolveCourseCode falls back when the roster entry has no course_code', () => {
+  assert.equal(resolveCourseCode({ email: 'a@berkeley.edu' }), DEFAULT_COURSE_CODE);
+});
+
+test('new student doc carries a course_code so the pipeline can route it', () => {
+  const student = buildNewStudent({
+    email: 'student@berkeley.edu',
+    displayName: 'Jo Student',
+    courseCode: 'CS61A',
+  });
+  assert.equal(student.course_code, 'CS61A');
+});
+
+test('new student doc keeps the existing default preferences', () => {
+  const student = buildNewStudent({
+    email: 'student@berkeley.edu',
+    displayName: 'Jo Student',
+    courseCode: 'CS61A',
+  });
+  assert.equal(student.email, 'student@berkeley.edu');
+  assert.equal(student.preferred_first_name, 'Jo');
+  assert.equal(student.days_before_deadline, 1);
+  assert.equal(student.release_reminder, true);
+});


### PR DESCRIPTION
## Problem

Today's daily job reported success and sent **2 emails against 202 enrolled students** — to `autoremind@berkeley.edu` and `lynn_kkcz@berkeley.edu`. Two independent bugs each narrowed the audience to the same few staff accounts, so either one alone would have produced "nobody but us."

## Bug 1 — course routing

`register.js` created student docs with **no `course_code`** field. Production reflected this exactly:

```
course_code distribution: {'CS61A': 4, 'None': 58}
```

`db_fetch.py` then fell through to a hardcoded fallback:

```python
course_lookup = lookup.get(course_code) or lookup.get("CS10")
```

`CS10` **exists** with 5 stale assignments, so this failed silently rather than erroring — 58 students were evaluated every day against five CS10 projects that expired in April 2026 and matched nothing.

- Removed the cross-course fallback.
- Unroutable students are now logged once each, so a run that drops people says so.
- Registration resolves `course_code` from `class_roster`, with a `COURSE_CODE` env fallback.

## Bug 2 — submission gate

`is_missing_submission` returned `False` for "no submission row", and the caller then `continue`d — skipping the student. A just-released assignment has no rows yet, so this silenced release-day reminders for the whole class.

Simulating Lab 7 (released that day) with course routing fixed:

```
  4  payload OK, status=missing        -> NOTIFIED
 58  payload OK but NO submission row  -> SKIPPED
```

All 62 matched the release window correctly; the submission gate alone killed 58. GradeSync row counts show why this would have recurred for every future assignment:

```
Lab 6 rows=209   |   Lab 7 rows=6   Lab 8 rows=6   Lab 9 rows=6   Scheme rows=6
```

Absence of a row is not evidence of a submission, so it now counts as not submitted. Only a recorded submission suppresses a reminder — covered by a guard test.

## Verified impact

Simulated against live production data (read-only):

| | built | past study gate | **notified** |
|---|---|---|---|
| Before | 4 | 2 | **2** ← matches prod logs |
| Fixed code only | 4 | 2 | **2** |
| Fixed code + backfill | 62 | 28 | **25** |

Release-reason lines go from 1 → 20. The code fix alone changes nothing in production — the 58 existing docs need `backfill_course_code.py` (dry run by default).

## Tests

Written first, each watched to fail for the right reason.

- **57 Python** (43 pre-existing + 14 new), including guard tests proving a recorded submission still suppresses reminders.
- **5 JS** via Node's built-in runner — no new dependency. Adds `npm test`.

The existing release-day tests only exercised `build_assignment_payload` directly; the submission gate lives one layer up in `_build_reminder_for_student`, which is why the feature shipped green and did nothing. New tests cover that layer.

## Not addressed here

60 group-1 consented students still have no student doc (never logged into the dashboard), and `email_pref` still defaults to `false` — that's why 25 rather than 28.